### PR TITLE
Add day-specific study hours with persistent UI toggle

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.1nlosrlm6m8"
+    "revision": "0.ss4vhicfd6o"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-ce4f0d5f'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.ss4vhicfd6o"
+    "revision": "0.arse48450r8"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -925,7 +925,7 @@ const CalendarView: React.FC<CalendarViewProps> = ({
         plannedTasks: [newSession],
         totalStudyHours: sessionDuration,
         isOverloaded: false,
-        availableHours: settings.dailyAvailableHours
+        availableHours: getDaySpecificDailyHours(newPlanDate, settings)
       });
 
       // Also remove from original plan if it exists

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -8,7 +8,7 @@ import 'react-big-calendar/lib/css/react-big-calendar.css';
 import 'react-big-calendar/lib/addons/dragAndDrop/styles.css';
 import { StudyPlan, FixedCommitment, Task, StudySession, UserSettings } from '../types';
 import { BookOpen, Clock, Settings, X, Calendar as CalendarIcon, Brain } from 'lucide-react';
-import { checkSessionStatus, doesCommitmentApplyToDate } from '../utils/scheduling';
+import { checkSessionStatus, doesCommitmentApplyToDate, getDaySpecificDailyHours } from '../utils/scheduling';
 import { getLocalDateString } from '../utils/scheduling';
 import MobileCalendarView from './MobileCalendarView';
 

--- a/src/components/MobileCalendarView.tsx
+++ b/src/components/MobileCalendarView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { ChevronLeft, ChevronRight, Clock, BookOpen, X, Play, Trash2 } from 'lucide-react';
 import { StudyPlan, FixedCommitment, Task, StudySession, UserSettings } from '../types';
-import { checkSessionStatus, formatTime, validateTimeSlot, doesCommitmentApplyToDate } from '../utils/scheduling';
+import { checkSessionStatus, formatTime, validateTimeSlot, doesCommitmentApplyToDate, getDaySpecificDailyHours } from '../utils/scheduling';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { TouchBackend } from 'react-dnd-touch-backend';
 import moment from 'moment';
@@ -446,7 +446,7 @@ const MobileCalendarView: React.FC<MobileCalendarViewProps> = ({
         plannedTasks: [newSession],
         totalStudyHours: sessionDuration,
         isOverloaded: false,
-        availableHours: settings.dailyAvailableHours
+        availableHours: getDaySpecificDailyHours(newPlanDate, settings)
       });
 
       const originalPlanIndex = updatedPlans.findIndex(plan => plan.date === originalDate);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -59,7 +59,9 @@ const Settings: React.FC<SettingsProps> = ({
   const [newDayHoursStudyHours, setNewDayHoursStudyHours] = useState(4);
 
   // State for toggling day-specific hours section visibility
-  const [showDaySpecificHoursSection, setShowDaySpecificHoursSection] = useState(false);
+  const [showDaySpecificHoursSection, setShowDaySpecificHoursSection] = useState(
+    (settings.daySpecificStudyHours && settings.daySpecificStudyHours.length > 0) || false
+  );
 
   // Update local state when settings prop changes (e.g., on initial load or external update)
   useEffect(() => {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -78,10 +78,11 @@ const Settings: React.FC<SettingsProps> = ({
     setDaySpecificStudyWindows(settings.daySpecificStudyWindows || []);
     setDaySpecificStudyHours(settings.daySpecificStudyHours || []);
 
-    // Keep section expanded if user has day-specific hours configured
-    if (settings.daySpecificStudyHours && settings.daySpecificStudyHours.length > 0) {
-      setShowDaySpecificHoursSection(true);
-    }
+    // Load persisted toggle preference, or default to expanded if user has day-specific hours
+    setShowDaySpecificHoursSection(
+      settings.showDaySpecificHoursSection ??
+      ((settings.daySpecificStudyHours && settings.daySpecificStudyHours.length > 0) || false)
+    );
   }, [settings]);
 
   // Enhanced validation functions with better error prevention

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -70,6 +70,7 @@ const Settings: React.FC<SettingsProps> = ({
     setStudyPlanMode(settings.studyPlanMode || 'even');
     setDateSpecificStudyWindows(settings.dateSpecificStudyWindows || []);
     setDaySpecificStudyWindows(settings.daySpecificStudyWindows || []);
+    setDaySpecificStudyHours(settings.daySpecificStudyHours || []);
   }, [settings]);
 
   // Enhanced validation functions with better error prevention

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -58,6 +58,9 @@ const Settings: React.FC<SettingsProps> = ({
   const [newDayHoursDayOfWeek, setNewDayHoursDayOfWeek] = useState(1); // Default to Monday
   const [newDayHoursStudyHours, setNewDayHoursStudyHours] = useState(4);
 
+  // State for toggling day-specific hours section visibility
+  const [showDaySpecificHoursSection, setShowDaySpecificHoursSection] = useState(false);
+
   // Update local state when settings prop changes (e.g., on initial load or external update)
   useEffect(() => {
     setDailyAvailableHours(settings.dailyAvailableHours);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -76,6 +76,11 @@ const Settings: React.FC<SettingsProps> = ({
     setDateSpecificStudyWindows(settings.dateSpecificStudyWindows || []);
     setDaySpecificStudyWindows(settings.daySpecificStudyWindows || []);
     setDaySpecificStudyHours(settings.daySpecificStudyHours || []);
+
+    // Keep section expanded if user has day-specific hours configured
+    if (settings.daySpecificStudyHours && settings.daySpecificStudyHours.length > 0) {
+      setShowDaySpecificHoursSection(true);
+    }
   }, [settings]);
 
   // Enhanced validation functions with better error prevention

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -60,7 +60,8 @@ const Settings: React.FC<SettingsProps> = ({
 
   // State for toggling day-specific hours section visibility
   const [showDaySpecificHoursSection, setShowDaySpecificHoursSection] = useState(
-    (settings.daySpecificStudyHours && settings.daySpecificStudyHours.length > 0) || false
+    settings.showDaySpecificHoursSection ??
+    ((settings.daySpecificStudyHours && settings.daySpecificStudyHours.length > 0) || false)
   );
 
   // Update local state when settings prop changes (e.g., on initial load or external update)

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -52,6 +52,12 @@ const Settings: React.FC<SettingsProps> = ({
   const [newDayOverrideStartHour, setNewDayOverrideStartHour] = useState(6);
   const [newDayOverrideEndHour, setNewDayOverrideEndHour] = useState(23);
 
+  // State for day-specific study hours form
+  const [showDaySpecificHoursForm, setShowDaySpecificHoursForm] = useState(false);
+  const [editingDayHours, setEditingDayHours] = useState<DaySpecificStudyHours | null>(null);
+  const [newDayHoursDayOfWeek, setNewDayHoursDayOfWeek] = useState(1); // Default to Monday
+  const [newDayHoursStudyHours, setNewDayHoursStudyHours] = useState(4);
+
   // Update local state when settings prop changes (e.g., on initial load or external update)
   useEffect(() => {
     setDailyAvailableHours(settings.dailyAvailableHours);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -223,7 +223,8 @@ const Settings: React.FC<SettingsProps> = ({
       enableNotifications: settings.enableNotifications !== false,
       studyPlanMode,
       dateSpecificStudyWindows,
-      daySpecificStudyWindows
+      daySpecificStudyWindows,
+      daySpecificStudyHours
     });
   };
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -236,7 +236,8 @@ const Settings: React.FC<SettingsProps> = ({
       studyPlanMode,
       dateSpecificStudyWindows,
       daySpecificStudyWindows,
-      daySpecificStudyHours
+      daySpecificStudyHours,
+      showDaySpecificHoursSection
     });
   };
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -584,7 +584,7 @@ const Settings: React.FC<SettingsProps> = ({
                 </label>
                 <button
                   type="button"
-                  onClick={() => setShowDaySpecificHoursSection(!showDaySpecificHoursSection)}
+                  onClick={handleToggleDaySpecificHoursSection}
                   className="px-3 py-1.5 bg-gradient-to-r from-purple-500 to-pink-500 text-white text-xs font-medium rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all duration-200 flex items-center gap-1.5"
                   title={showDaySpecificHoursSection ? "Hide day-specific hours" : "Set different hours for specific days"}
                 >

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -35,6 +35,7 @@ const Settings: React.FC<SettingsProps> = ({
   const [studyPlanMode, setStudyPlanMode] = useState(settings.studyPlanMode || 'even');
   const [dateSpecificStudyWindows, setDateSpecificStudyWindows] = useState<DateSpecificStudyWindow[]>(settings.dateSpecificStudyWindows || []);
   const [daySpecificStudyWindows, setDaySpecificStudyWindows] = useState<DaySpecificStudyWindow[]>(settings.daySpecificStudyWindows || []);
+  const [daySpecificStudyHours, setDaySpecificStudyHours] = useState<DaySpecificStudyHours[]>(settings.daySpecificStudyHours || []);
 
   // State for date-specific override form
   const [showDateSpecificForm, setShowDateSpecificForm] = useState(false);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Settings as SettingsIcon, Clock, AlertTriangle, Calendar, Zap, Sun, Plus, Trash2, Edit3 } from 'lucide-react';
-import { UserSettings, StudyPlan, DateSpecificStudyWindow, DaySpecificStudyWindow } from '../types';
+import { UserSettings, StudyPlan, DateSpecificStudyWindow, DaySpecificStudyWindow, DaySpecificStudyHours } from '../types';
 
 interface SettingsProps {
   settings: UserSettings;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -574,6 +574,7 @@ const Settings: React.FC<SettingsProps> = ({
         </div>
 
         {/* Day-Specific Study Hours */}
+        {showDaySpecificHoursSection && (
         <div className="backdrop-blur-sm bg-white/50 dark:bg-white/5 rounded-2xl p-5 border border-white/20 dark:border-white/10 transition-all duration-300 hover:bg-white/60 dark:hover:bg-white/10">
           <div className="flex items-center justify-between mb-3">
             <label className="flex text-sm font-semibold text-gray-700 dark:text-gray-200 items-center space-x-2">
@@ -715,6 +716,7 @@ const Settings: React.FC<SettingsProps> = ({
             </div>
           )}
         </div>
+        )}
 
         {/* Buffer Days */}
         <div>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -251,6 +251,29 @@ const Settings: React.FC<SettingsProps> = ({
 
   const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
+  // Handle day-specific hours section toggle with immediate save
+  const handleToggleDaySpecificHoursSection = () => {
+    const newToggleState = !showDaySpecificHoursSection;
+    setShowDaySpecificHoursSection(newToggleState);
+
+    // Immediately save the toggle preference
+    onUpdateSettings({
+      ...settings,
+      dailyAvailableHours,
+      workDays,
+      bufferDays,
+      minSessionLength,
+      bufferTimeBetweenSessions,
+      studyWindowStartHour,
+      studyWindowEndHour,
+      studyPlanMode,
+      dateSpecificStudyWindows,
+      daySpecificStudyWindows,
+      daySpecificStudyHours,
+      showDaySpecificHoursSection: newToggleState
+    });
+  };
+
   // Helper function to check if a setting is disabled
   const isSettingDisabled = (settingKey: string) => {
     return !canChangeSetting(settingKey);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -452,6 +452,29 @@ const Settings: React.FC<SettingsProps> = ({
     return { isValid: true, message: '' };
   };
 
+  const validateDaySpecificHours = (): { isValid: boolean; message: string } => {
+    if (newDayHoursStudyHours <= 0) {
+      return { isValid: false, message: 'Study hours must be greater than 0.' };
+    }
+    if (newDayHoursStudyHours > 24) {
+      return { isValid: false, message: 'Study hours cannot exceed 24 hours.' };
+    }
+
+    // Check if there's a day-specific window for this day and validate against it
+    const dayWindow = daySpecificStudyWindows.find(w => w.dayOfWeek === newDayHoursDayOfWeek && w.isActive);
+    if (dayWindow) {
+      const windowHours = dayWindow.endHour - dayWindow.startHour;
+      if (newDayHoursStudyHours > windowHours) {
+        return {
+          isValid: false,
+          message: `Study hours (${newDayHoursStudyHours}h) cannot exceed the study window duration (${windowHours}h) for ${getDayName(newDayHoursDayOfWeek)}.`
+        };
+      }
+    }
+
+    return { isValid: true, message: '' };
+  };
+
   const cancelDateSpecificForm = () => {
     setShowDateSpecificForm(false);
     setEditingOverride(null);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -542,12 +542,23 @@ const Settings: React.FC<SettingsProps> = ({
           <div className="space-y-6">
         {/* Daily Available Hours */}
         <div className="backdrop-blur-sm bg-white/50 dark:bg-white/5 rounded-2xl p-5 border border-white/20 dark:border-white/10 transition-all duration-300 hover:bg-white/60 dark:hover:bg-white/10">
-              <label htmlFor="dailyHours" className="flex text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2 items-center space-x-2">
-                <div className="w-6 h-6 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-lg flex items-center justify-center">
-                  <Clock size={14} className="text-white" />
-                </div>
-            <span>How many hours can you study per day?</span>
-          </label>
+              <div className="flex items-center justify-between mb-2">
+                <label htmlFor="dailyHours" className="flex text-sm font-semibold text-gray-700 dark:text-gray-200 items-center space-x-2">
+                  <div className="w-6 h-6 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-lg flex items-center justify-center">
+                    <Clock size={14} className="text-white" />
+                  </div>
+                  <span>How many hours can you study per day?</span>
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setShowDaySpecificHoursSection(!showDaySpecificHoursSection)}
+                  className="px-3 py-1.5 bg-gradient-to-r from-purple-500 to-pink-500 text-white text-xs font-medium rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all duration-200 flex items-center gap-1.5"
+                  title={showDaySpecificHoursSection ? "Hide day-specific hours" : "Set different hours for specific days"}
+                >
+                  <Calendar size={12} />
+                  {showDaySpecificHoursSection ? 'Hide Day-Specific' : 'Day-Specific Hours'}
+                </button>
+              </div>
               <p className="text-xs text-gray-600 dark:text-gray-400 mb-3">This includes all your study time for the day.</p>
           <input
             type="number"

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -368,6 +368,64 @@ const Settings: React.FC<SettingsProps> = ({
     setDaySpecificStudyWindows(updatedOverrides);
   };
 
+  // Day-specific study hours handlers
+  const handleAddDaySpecificHours = () => {
+    const validation = validateDaySpecificHours();
+    if (!validation.isValid) {
+      alert(validation.message);
+      return;
+    }
+
+    // Check if hours for this day already exists
+    const existingIndex = daySpecificStudyHours.findIndex(hours => hours.dayOfWeek === newDayHoursDayOfWeek);
+
+    if (existingIndex !== -1) {
+      // Update existing hours
+      const updatedHours = [...daySpecificStudyHours];
+      updatedHours[existingIndex] = {
+        dayOfWeek: newDayHoursDayOfWeek,
+        studyHours: newDayHoursStudyHours,
+        isActive: true
+      };
+      setDaySpecificStudyHours(updatedHours);
+    } else {
+      // Add new day-specific hours
+      const newHours: DaySpecificStudyHours = {
+        dayOfWeek: newDayHoursDayOfWeek,
+        studyHours: newDayHoursStudyHours,
+        isActive: true
+      };
+      setDaySpecificStudyHours([...daySpecificStudyHours, newHours]);
+    }
+
+    // Reset form
+    setShowDaySpecificHoursForm(false);
+    setEditingDayHours(null);
+    setNewDayHoursDayOfWeek(1);
+    setNewDayHoursStudyHours(4);
+  };
+
+  const handleEditDaySpecificHours = (hours: DaySpecificStudyHours) => {
+    setEditingDayHours(hours);
+    setNewDayHoursDayOfWeek(hours.dayOfWeek);
+    setNewDayHoursStudyHours(hours.studyHours);
+    setShowDaySpecificHoursForm(true);
+  };
+
+  const handleDeleteDaySpecificHours = (dayOfWeek: number) => {
+    const updatedHours = daySpecificStudyHours.filter(hours => hours.dayOfWeek !== dayOfWeek);
+    setDaySpecificStudyHours(updatedHours);
+  };
+
+  const handleToggleDayHoursActive = (dayOfWeek: number) => {
+    const updatedHours = daySpecificStudyHours.map(hours =>
+      hours.dayOfWeek === dayOfWeek
+        ? { ...hours, isActive: !hours.isActive }
+        : hours
+    );
+    setDaySpecificStudyHours(updatedHours);
+  };
+
   const formatTimeDisplay = (hour: number): string => {
     return hour === 0 ? '12 AM' : hour < 12 ? `${hour} AM` : hour === 12 ? '12 PM' : `${hour - 12} PM`;
   };

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -559,6 +559,149 @@ const Settings: React.FC<SettingsProps> = ({
           />
         </div>
 
+        {/* Day-Specific Study Hours */}
+        <div className="backdrop-blur-sm bg-white/50 dark:bg-white/5 rounded-2xl p-5 border border-white/20 dark:border-white/10 transition-all duration-300 hover:bg-white/60 dark:hover:bg-white/10">
+          <div className="flex items-center justify-between mb-3">
+            <label className="flex text-sm font-semibold text-gray-700 dark:text-gray-200 items-center space-x-2">
+              <div className="w-6 h-6 bg-gradient-to-r from-purple-500 to-pink-500 rounded-lg flex items-center justify-center">
+                <Calendar size={14} className="text-white" />
+              </div>
+              <span>Day-Specific Study Hours</span>
+            </label>
+            <button
+              type="button"
+              onClick={() => setShowDaySpecificHoursForm(true)}
+              className="px-3 py-1.5 bg-gradient-to-r from-purple-500 to-pink-500 text-white text-xs font-medium rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all duration-200 flex items-center gap-1.5"
+            >
+              <Plus size={12} />
+              Add Day
+            </button>
+          </div>
+
+          <p className="text-xs text-gray-600 dark:text-gray-400 mb-4">
+            Set different study hour targets for specific days of the week. If not set, the default daily hours will be used.
+          </p>
+
+          {/* Existing Day-Specific Hours */}
+          {daySpecificStudyHours.length > 0 && (
+            <div className="space-y-2 mb-4">
+              {daySpecificStudyHours.map((hours) => (
+                <div
+                  key={hours.dayOfWeek}
+                  className={`flex items-center justify-between p-3 rounded-lg border transition-all duration-200 ${hours.isActive
+                    ? 'bg-purple-50 dark:bg-purple-900/20 border-purple-200 dark:border-purple-700'
+                    : 'bg-gray-50 dark:bg-gray-800/50 border-gray-200 dark:border-gray-700'
+                  }`}
+                >
+                  <div className="flex items-center space-x-3">
+                    <span className={`text-sm font-medium ${hours.isActive ? 'text-purple-700 dark:text-purple-300' : 'text-gray-500 dark:text-gray-400'}`}>
+                      {getDayName(hours.dayOfWeek)}
+                    </span>
+                    <span className={`text-sm ${hours.isActive ? 'text-purple-600 dark:text-purple-400' : 'text-gray-500 dark:text-gray-400'}`}>
+                      {hours.studyHours}h
+                    </span>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    <button
+                      type="button"
+                      className={`px-2 py-1 text-xs font-medium rounded-full transition-colors ${hours.isActive
+                        ? 'bg-green-100 text-green-800 hover:bg-green-200'
+                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                      }`}
+                      onClick={() => handleToggleDayHoursActive(hours.dayOfWeek)}
+                    >
+                      {hours.isActive ? 'Active' : 'Inactive'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleEditDaySpecificHours(hours)}
+                      className="p-1.5 text-blue-600 hover:bg-blue-100 rounded transition-colors"
+                      title="Edit hours"
+                    >
+                      <Edit3 size={12} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteDaySpecificHours(hours.dayOfWeek)}
+                      className="p-1.5 text-red-600 hover:bg-red-100 rounded transition-colors"
+                      title="Delete hours"
+                    >
+                      <Trash2 size={12} />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Add/Edit Day-Specific Hours Form */}
+          {showDaySpecificHoursForm && (
+            <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700">
+              <h4 className="text-sm font-medium text-gray-700 dark:text-gray-200 mb-3">
+                {editingDayHours ? 'Edit' : 'Add'} Day-Specific Hours
+              </h4>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                    Day of Week
+                  </label>
+                  <select
+                    value={newDayHoursDayOfWeek}
+                    onChange={(e) => setNewDayHoursDayOfWeek(Number(e.target.value))}
+                    className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                  >
+                    <option value={0}>Sunday</option>
+                    <option value={1}>Monday</option>
+                    <option value={2}>Tuesday</option>
+                    <option value={3}>Wednesday</option>
+                    <option value={4}>Thursday</option>
+                    <option value={5}>Friday</option>
+                    <option value={6}>Saturday</option>
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                    Study Hours
+                  </label>
+                  <input
+                    type="number"
+                    value={newDayHoursStudyHours}
+                    onChange={(e) => setNewDayHoursStudyHours(Number(e.target.value))}
+                    min="0.5"
+                    max="24"
+                    step="0.5"
+                    className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                  />
+                </div>
+              </div>
+
+              <div className="flex justify-end space-x-2 mt-4">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowDaySpecificHoursForm(false);
+                    setEditingDayHours(null);
+                    setNewDayHoursDayOfWeek(1);
+                    setNewDayHoursStudyHours(4);
+                  }}
+                  className="px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleAddDaySpecificHours}
+                  className="px-3 py-1.5 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700 transition-colors"
+                >
+                  {editingDayHours ? 'Update' : 'Add'} Hours
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+
         {/* Buffer Days */}
         <div>
               <label htmlFor="bufferDays" className="flex text-sm font-medium text-gray-700 mb-1 items-center space-x-2 dark:text-gray-200">

--- a/src/components/StudyPlanView.tsx
+++ b/src/components/StudyPlanView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Calendar, Clock, BookOpen, TrendingUp, AlertTriangle, CheckCircle, Lightbulb, X, CheckCircle2, Clock3, Settings } from 'lucide-react';
 import { StudyPlan, Task, StudySession, FixedCommitment, UserSettings } from '../types';
-import { formatTime, generateSmartSuggestions, getLocalDateString, checkSessionStatus, moveIndividualSession, isTaskDeadlinePast, calculateCommittedHoursForDate } from '../utils/scheduling';
+import { formatTime, generateSmartSuggestions, getLocalDateString, checkSessionStatus, moveIndividualSession, isTaskDeadlinePast, calculateCommittedHoursForDate, getDaySpecificDailyHours } from '../utils/scheduling';
 
 interface StudyPlanViewProps {
   studyPlans: StudyPlan[];
@@ -614,12 +614,13 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
                 }).reduce((sum, session) => sum + session.allocatedHours, 0);
                 const committedHours = calculateCommittedHoursForDate(todaysPlan.date, fixedCommitments);
                 const totalPlannedHours = taskHours + committedHours;
-                const remainingHours = Math.max(0, settings.dailyAvailableHours - totalPlannedHours);
+                const dailyCapacity = getDaySpecificDailyHours(todaysPlan.date, settings);
+                const remainingHours = Math.max(0, dailyCapacity - totalPlannedHours);
 
                 return (
                   <div className="space-y-1">
                     <div className="text-lg font-bold text-gray-800 dark:text-white">
-                      {formatTime(totalPlannedHours)} / {formatTime(settings.dailyAvailableHours)}
+                      {formatTime(totalPlannedHours)} / {formatTime(dailyCapacity)}
                     </div>
                     <div className="text-xs text-gray-600 dark:text-gray-400 space-y-0.5">
                       <div>📝 Tasks: {formatTime(taskHours)}</div>
@@ -709,7 +710,8 @@ const StudyPlanView: React.FC<StudyPlanViewProps> = ({ studyPlans, tasks, fixedC
                       }).reduce((sum, session) => sum + session.allocatedHours, 0);
                       const committedHours = calculateCommittedHoursForDate(todaysPlan.date, fixedCommitments);
                       const totalHours = taskHours + committedHours;
-                      return `${formatTime(totalHours)} / ${formatTime(settings.dailyAvailableHours)} total hours`;
+                      const dailyCapacity = getDaySpecificDailyHours(plan.date, settings);
+                      return `${formatTime(totalHours)} / ${formatTime(dailyCapacity)} total hours`;
                     })()})
                   </span>
                   <span className="text-xs text-blue-500 dark:text-blue-400" title="Buffer time between sessions is not counted in study hours">

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,8 @@ export interface UserSettings {
   dateSpecificStudyWindows?: DateSpecificStudyWindow[]; // Override study windows for specific dates
   // Day-specific study windows (optional)
   daySpecificStudyWindows?: DaySpecificStudyWindow[]; // Override study windows for specific days of the week
+  // Day-specific study hours (optional)
+  daySpecificStudyHours?: DaySpecificStudyHours[]; // Override daily study hours for specific days of the week
 }
 
 export interface TimerState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,8 @@ export interface UserSettings {
   daySpecificStudyWindows?: DaySpecificStudyWindow[]; // Override study windows for specific days of the week
   // Day-specific study hours (optional)
   daySpecificStudyHours?: DaySpecificStudyHours[]; // Override daily study hours for specific days of the week
+  // UI preference for showing day-specific hours section
+  showDaySpecificHoursSection?: boolean; // Whether to show the day-specific hours section in settings
 }
 
 export interface TimerState {

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,12 @@ export interface DaySpecificStudyWindow {
   isActive: boolean; // Whether this override is active
 }
 
+export interface DaySpecificStudyHours {
+  dayOfWeek: number; // 0=Sunday, 1=Monday, 2=Tuesday, etc.
+  studyHours: number; // Hours available for study on this day
+  isActive: boolean; // Whether this override is active
+}
+
 export interface UserSettings {
   dailyAvailableHours: number;
   workDays: number[]; // Days of week user wants to work (0=Sunday, 1=Monday, etc.)

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -1,4 +1,23 @@
-import { Task, StudyPlan, StudySession, UserSettings, FixedCommitment, UserReschedule, DateSpecificStudyWindow, SkipMetadata } from '../types';
+import { Task, StudyPlan, StudySession, UserSettings, FixedCommitment, UserReschedule, DateSpecificStudyWindow, DaySpecificStudyHours, SkipMetadata } from '../types';
+
+// Helper function to get day-specific daily hours
+export const getDaySpecificDailyHours = (date: string, settings: UserSettings): number => {
+  const targetDate = new Date(date);
+  const dayOfWeek = targetDate.getDay();
+
+  // Check for day-specific study hours
+  if (settings.daySpecificStudyHours) {
+    const daySpecific = settings.daySpecificStudyHours.find(
+      hours => hours.dayOfWeek === dayOfWeek && hours.isActive
+    );
+    if (daySpecific) {
+      return daySpecific.studyHours;
+    }
+  }
+
+  // Fall back to default daily available hours
+  return settings.dailyAvailableHours;
+};
 
 // Helper function to calculate committed hours for a specific date that count toward daily hours
 export const calculateCommittedHoursForDate = (date: string, commitments: FixedCommitment[]): number => {

--- a/src/utils/scheduling.ts
+++ b/src/utils/scheduling.ts
@@ -1271,7 +1271,7 @@ export const generateNewStudyPlan = (
     availableDays.forEach(date => {
       // Calculate committed hours for this date that count toward daily hours
       const committedHours = calculateCommittedHoursForDate(date, fixedCommitments);
-      const availableHoursAfterCommitments = Math.max(0, settings.dailyAvailableHours - committedHours);
+      const availableHoursAfterCommitments = Math.max(0, getDaySpecificDailyHours(date, settings) - committedHours);
 
       dailyRemainingHours[date] = availableHoursAfterCommitments;
       studyPlans.push({
@@ -2042,7 +2042,7 @@ export const generateNewStudyPlan = (
     availableDays.forEach(date => {
       // Calculate committed hours for this date that count toward daily hours
       const committedHours = calculateCommittedHoursForDate(date, fixedCommitments);
-      const availableHoursAfterCommitments = Math.max(0, settings.dailyAvailableHours - committedHours);
+      const availableHoursAfterCommitments = Math.max(0, getDaySpecificDailyHours(date, settings) - committedHours);
 
       dailyRemainingHours[date] = availableHoursAfterCommitments;
       studyPlans.push({
@@ -2342,7 +2342,7 @@ export const generateNewStudyPlan = (
   availableDays.forEach(date => {
     // Calculate committed hours for this date that count toward daily hours
     const committedHours = calculateCommittedHoursForDate(date, fixedCommitments);
-    const availableHoursAfterCommitments = Math.max(0, settings.dailyAvailableHours - committedHours);
+    const availableHoursAfterCommitments = Math.max(0, getDaySpecificDailyHours(date, settings) - committedHours);
 
     dailyRemainingHours[date] = availableHoursAfterCommitments;
     studyPlans.push({
@@ -3032,7 +3032,7 @@ export const redistributeAfterTaskDeletion = (
   availableDays.forEach(date => {
     // Calculate committed hours for this date that count toward daily hours
     const committedHours = calculateCommittedHoursForDate(date, fixedCommitments);
-    const availableHoursAfterCommitments = Math.max(0, settings.dailyAvailableHours - committedHours);
+    const availableHoursAfterCommitments = Math.max(0, getDaySpecificDailyHours(date, settings) - committedHours);
 
     dailyRemainingHours[date] = availableHoursAfterCommitments;
     studyPlans.push({


### PR DESCRIPTION
## Purpose

The user requested the ability to hide/show the day-specific section in the settings, with the toggle state persisting across sessions unless manually changed again. This enhances the user experience by allowing customization of the interface while maintaining their preferences.

## Code changes

- **Added new type `DaySpecificStudyHours`** to define study hours for specific days of the week
- **Enhanced `UserSettings`** with `daySpecificStudyHours` array and `showDaySpecificHoursSection` boolean for UI state persistence
- **Implemented `getDaySpecificDailyHours()` utility function** to retrieve day-specific hours with fallback to default settings
- **Updated Settings component** with:
  - New form section for managing day-specific study hours
  - Persistent toggle functionality that immediately saves state changes
  - CRUD operations for day-specific hours (add, edit, delete, toggle active)
- **Modified calendar components** (CalendarView, MobileCalendarView, StudyPlanView) to use day-specific hours when calculating available time
- **Updated scheduling utilities** to respect day-specific hours throughout the planning algorithms
- **Enhanced service worker** with updated revision hash for deployment

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/63bc11aabeeb4834a3cc3474ee896be9/neon-zone)

👀 [Preview Link](https://63bc11aabeeb4834a3cc3474ee896be9-neon-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>63bc11aabeeb4834a3cc3474ee896be9</projectId>-->
<!--<branchName>neon-zone</branchName>-->